### PR TITLE
Build Before Debug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "cmsis-dap-debug",
+            "name": "cmsis-dap-debug (Windows)",
             "cwd": "${workspaceRoot}",
             "executable": "${workspaceRoot}\\build\\control-base.elf",
             "request": "launch",
@@ -17,7 +17,8 @@
             "liveWatch": { 
                 "enabled": true,
                 "samplesPerSecond": 4
-            }
+            },
+            "preLaunchTask": "build (Windows)" // build before debug
         },
         {
             "name": "cmsis-dap-debug (Darwin)",
@@ -35,7 +36,8 @@
             "liveWatch": { 
                 "enabled": true,
                 "samplesPerSecond": 4
-            }
+            },
+            "preLaunchTask": "build (Darwin)" // build before debug
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
         {
             "label": "build (Darwin)",
             "type": "shell",
-            "command": "make",
+            "command": "make -j24 V=1",
             "args": [],
             "group": {
                 "kind": "build",


### PR DESCRIPTION
adds the task of building the project before starting the debugger

needs windows testing before merge